### PR TITLE
fix: 修复 prefab 验证脚本以支持文件初始化

### DIFF
--- a/prefabs/releases/scripts/extract_pr_changes.py
+++ b/prefabs/releases/scripts/extract_pr_changes.py
@@ -23,14 +23,18 @@ def main():
     """主函数"""
     try:
         # 获取 base 和 head 的文件内容
-        base_content = run_command([
-            'git', 'show', 'origin/main:community-prefabs.json'
-        ])
+        try:
+            base_content = run_command([
+                'git', 'show', 'origin/main:prefabs/releases/community-prefabs.json'
+            ])
+            base_data = json.loads(base_content) if base_content else []
+        except subprocess.CalledProcessError:
+            # 文件在 main 分支不存在，视为空数组
+            base_data = []
+        
         head_content = run_command([
-            'git', 'show', 'HEAD:community-prefabs.json'
+            'git', 'show', 'HEAD:prefabs/releases/community-prefabs.json'
         ])
-
-        base_data = json.loads(base_content) if base_content else []
         head_data = json.loads(head_content)
 
         # 创建字典方便查找


### PR DESCRIPTION
## 问题

当 main 分支上还没有 `community-prefabs.json` 文件时，`extract_pr_changes.py` 会因为找不到文件而失败。

## 修复

1. 添加异常处理，捕获 `CalledProcessError`
2. 当文件在 main 分支不存在时，视为空数组 `[]`
3. 修正文件路径为完整路径 `prefabs/releases/community-prefabs.json`

## 测试

修复后，脚本将能够正确处理文件不存在的情况，为后续初始化 PR 做准备。