### PR TITLE
fix: 允许 prefab tags 使用中文标签

### DIFF
--- a/prefabs/releases/schema.json
+++ b/prefabs/releases/schema.json
@@ -52,10 +52,11 @@
       },
       "tags": {
         "type": "array",
-        "description": "Tags for categorization and discovery",
+        "description": "Tags for categorization and discovery (supports Chinese and English)",
         "items": {
           "type": "string",
-          "pattern": "^[a-z0-9-]+$"
+          "minLength": 1,
+          "maxLength": 50
         },
         "uniqueItems": true,
         "maxItems": 10


### PR DESCRIPTION
## 问题

当前 schema.json 中 tags 字段限制只能使用小写字母、数字和连字符 (`^[a-z0-9-]+$`)，不支持中文标签。

## 修改内容

- 移除 tags 的正则表达式 pattern 限制
- 改为使用 minLength/maxLength (1-50 字符) 限制长度
- 更新 description 说明支持中英文标签

## 影响

此修改允许社区贡献者使用中文标签来标记 prefab，提升中文用户的搜索和发现体验。

## 相关

需要在 PR #91 之前合并，以便 llm-client prefab 可以使用中文标签。