### PR TITLE
fix: 修复手动部署时 JSON 输出格式问题

### DIFF
--- a/.github/workflows/prefab-deploy-webhook.yml
+++ b/.github/workflows/prefab-deploy-webhook.yml
@@ -106,9 +106,14 @@ jobs:
                   for item in changed:
                       print(f"  - {item['id']}@{item['version']}")
           
-          # 输出到 GitHub Actions
+          # 输出到 GitHub Actions（使用多行输出格式避免 JSON 转义问题）
+          import uuid
+          delimiter = f"ghadelimiter_{uuid.uuid4()}"
+          
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-              f.write(f"changed_entries={json.dumps(changed)}\n")
+              f.write(f"changed_entries<<{delimiter}\n")
+              f.write(json.dumps(changed))
+              f.write(f"\n{delimiter}\n")
               f.write(f"has_changes={'true' if changed else 'false'}\n")
           PYTHON_SCRIPT
 


### PR DESCRIPTION
## Summary
修复手动触发部署时 `changed_entries` 为空的问题

## 问题
手动触发部署时报错：`No changed entries data received`

## 原因
GitHub Actions 单行输出在处理包含特殊字符的 JSON 时可能出现转义问题

## 解决方案
使用 GitHub Actions 的多行输出格式（heredoc）来传递 JSON 数据：
```yaml
changed_entries<<{delimiter}
{json_data}
{delimiter}
```

## Test plan
- [ ] 测试手动触发部署 llm-client 1.0.1
- [ ] 验证自动触发功能仍正常工作

🤖 Generated with [Claude Code](https://claude.ai/code)