### PR TITLE
fix: 使用环境变量传递 changed_entries 避免 heredoc 冲突

### DIFF
--- a/.github/workflows/prefab-deploy-webhook.yml
+++ b/.github/workflows/prefab-deploy-webhook.yml
@@ -122,12 +122,10 @@ jobs:
         env:
           FACTORY_URL: ${{ secrets.PREFAB_FACTORY_DEPLOY_URL }}
           WEBHOOK_SECRET: ${{ secrets.PREFAB_FACTORY_WEBHOOK_SECRET }}
+          CHANGED_ENTRIES: ${{ steps.extract.outputs.changed_entries }}
         run: |
-          # 读取变更的条目
-          CHANGED_ENTRIES='${{ steps.extract.outputs.changed_entries }}'
-
           # 遍历每个变更的条目，下载 .whl 并上传到 factory
-          echo "$CHANGED_ENTRIES" | python3 << 'PYTHON_SCRIPT'
+          python3 << 'PYTHON_SCRIPT'
           import json
           import os
           import sys
@@ -139,7 +137,8 @@ jobs:
           import hashlib
           import hmac
 
-          input_data = sys.stdin.read().strip()
+          # 从环境变量读取变更条目（避免 heredoc 与管道冲突）
+          input_data = os.environ.get('CHANGED_ENTRIES', '').strip()
           if not input_data:
               print("::error::No changed entries data received")
               sys.exit(1)


### PR DESCRIPTION
## Summary
修复手动触发部署时 `No changed entries data received` 的根本原因

## 问题分析
之前的实现：
```yaml
CHANGED_ENTRIES='${{ steps.extract.outputs.changed_entries }}'
echo "$CHANGED_ENTRIES" | python3 << 'PYTHON_SCRIPT'
input_data = sys.stdin.read()
```

问题：`echo | python3 << 'HEREDOC'` 不工作，因为 heredoc 语法会覆盖来自管道的 stdin，导致 Python 读取到的是空字符串。

## 解决方案
通过环境变量传递数据：
```yaml
env:
  CHANGED_ENTRIES: ${{ steps.extract.outputs.changed_entries }}
run: |
  python3 << 'PYTHON_SCRIPT'
  input_data = os.environ.get('CHANGED_ENTRIES', '')
```

## 测试
已创建本地测试脚本 `test-fix.sh` 验证修复有效：
```
✅ 成功解析 1 个条目
  - llm-client@1.0.1: 大模型客户端预制件
```

## Test plan
- [x] 本地测试脚本验证通过
- [ ] GitHub Actions 手动触发测试
- [ ] 验证自动触发功能仍正常

🤖 Generated with [Claude Code](https://claude.ai/code)