### PR TITLE
fix: 禁用 SSL 证书验证以支持自签名证书

### DIFF
--- a/.github/workflows/prefab-deploy-webhook.yml
+++ b/.github/workflows/prefab-deploy-webhook.yml
@@ -129,6 +129,7 @@ jobs:
           import json
           import os
           import sys
+          import ssl
           import tempfile
           from pathlib import Path
           from urllib.parse import urlparse, urlencode
@@ -136,6 +137,9 @@ jobs:
           import mimetypes
           import hashlib
           import hmac
+
+          # 创建不验证 SSL 证书的上下文（用于自签名证书）
+          ssl_context = ssl._create_unverified_context()
 
           # 从环境变量读取变更条目（避免 heredoc 与管道冲突）
           input_data = os.environ.get('CHANGED_ENTRIES', '').strip()
@@ -241,7 +245,7 @@ jobs:
                           headers['X-Hub-Signature-256'] = signature
 
                       request = Request(deploy_url, data=body, headers=headers, method='POST')
-                      with urlopen(request, timeout=60) as response:
+                      with urlopen(request, timeout=60, context=ssl_context) as response:
                           response_data = response.read().decode('utf-8')
                           status_code = response.status
 


### PR DESCRIPTION
## Summary
修复上传到 Prefab Factory 时的 SSL 证书验证错误

## 问题
```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] 
certificate verify failed: self-signed certificate
```

Prefab Factory 服务器使用自签名证书，Python 的 urllib 默认会验证证书，导致连接失败。

## 解决方案
创建不验证 SSL 证书的上下文并在 urlopen 调用时使用：
```python
ssl_context = ssl._create_unverified_context()
urlopen(request, timeout=60, context=ssl_context)
```

## 安全说明
仅在上传到 Prefab Factory 时禁用验证。从 GitHub 下载 .whl 文件仍使用默认的 SSL 验证。

## Test plan
- [ ] 手动触发部署 llm-client 1.0.1
- [ ] 验证能成功连接到 Factory 服务器

🤖 Generated with [Claude Code](https://claude.ai/code)