### PR TITLE
fix: 修复 multipart/form-data 格式错误并添加详细错误日志

### DIFF
--- a/.github/workflows/prefab-deploy-webhook.yml
+++ b/.github/workflows/prefab-deploy-webhook.yml
@@ -209,30 +209,29 @@ jobs:
 
                       # 构建 multipart form data（手动构建，避免依赖 requests 库）
                       boundary = '----WebKitFormBoundary' + os.urandom(16).hex()
-                      parts = []
+                      body_parts = []
 
                       # 添加文本字段
                       for field_name, field_value in [
                           ('prefab_id', prefab_id),
                           ('version', version)
                       ]:
-                          parts.append(f'--{boundary}'.encode())
-                          parts.append(f'Content-Disposition: form-data; name="{field_name}"'.encode())
-                          parts.append(b'')
-                          parts.append(str(field_value).encode())
+                          body_parts.append(f'--{boundary}\r\n'.encode())
+                          body_parts.append(f'Content-Disposition: form-data; name="{field_name}"\r\n\r\n'.encode())
+                          body_parts.append(f'{field_value}\r\n'.encode())
 
                       # 添加文件字段
-                      parts.append(f'--{boundary}'.encode())
-                      parts.append(
-                          f'Content-Disposition: form-data; name="whl_file"; filename="{whl_filename}"'.encode()
+                      body_parts.append(f'--{boundary}\r\n'.encode())
+                      body_parts.append(
+                          f'Content-Disposition: form-data; name="whl_file"; filename="{whl_filename}"\r\n'.encode()
                       )
-                      parts.append(b'Content-Type: application/octet-stream')
-                      parts.append(b'')
-                      parts.append(file_content)  # 使用已读取的内容
-                      parts.append(f'--{boundary}--'.encode())
+                      body_parts.append(b'Content-Type: application/octet-stream\r\n\r\n')
+                      body_parts.append(file_content)
+                      body_parts.append(b'\r\n')
+                      body_parts.append(f'--{boundary}--\r\n'.encode())
 
                       # 组装请求体
-                      body = b'\r\n'.join(parts)
+                      body = b''.join(body_parts)
 
                       # 发送请求
                       headers = {


### PR DESCRIPTION
## Summary
- 修复 multipart/form-data 构建格式错误（导致 500 错误的根本原因）
- 添加详细的 HTTP 错误响应日志

## 问题 1: multipart 格式错误
之前使用 `b'\r\n'.join(parts)` 构建请求体，导致边界分隔符缺失。

**修复前：**
```python
parts = [b'--boundary', b'Content-Disposition...', b'', b'value']
body = b'\r\n'.join(parts)
# 结果：--boundary\r\nContent-Disposition...\r\n\r\nvalue
```

**修复后：**
```python
body_parts = [
    b'--boundary\r\n',
    b'Content-Disposition...\r\n\r\n',
    b'value\r\n'
]
body = b''.join(body_parts)
```

现在格式符合 RFC 2388 标准，FastAPI 可以正确解析。

## 问题 2: 缺少详细错误信息
添加了详细的 HTTP 错误响应日志，显示服务器返回的错误详情。

## Test plan
- [ ] 手动触发部署 llm-client 1.0.1
- [ ] 验证能成功上传并触发部署任务

🤖 Generated with [Claude Code](https://claude.ai/code)