### PR TITLE
fix: 修正 multipart boundary 前导破折号问题

### DIFF
--- a/.github/workflows/prefab-deploy-webhook.yml
+++ b/.github/workflows/prefab-deploy-webhook.yml
@@ -208,7 +208,8 @@ jobs:
                       print(f"⬆️  Uploading to factory: {deploy_url}")
 
                       # 构建 multipart form data（手动构建，避免依赖 requests 库）
-                      boundary = '----WebKitFormBoundary' + os.urandom(16).hex()
+                      # boundary 不应包含前导破折号，破折号只在使用时添加
+                      boundary = 'WebKitFormBoundary' + os.urandom(16).hex()
                       body_parts = []
 
                       # 添加文本字段


### PR DESCRIPTION
## Summary
修正 multipart/form-data boundary 的前导破折号问题，解决 FastAPI 解析错误

## 问题
服务器日志显示：
```
RequestValidationError: Input should be a valid dictionary or object to extract fields from
Input: b'------WebKitFormBoundary...\r\n...'
```

boundary 有 **6 个破折号**，但 RFC 2046 标准要求只有 **2 个破折号**。

## 根本原因
```python
boundary = '----WebKitFormBoundary' + random_hex  # 4个破折号
body_parts.append(f'--{boundary}\r\n')            # 又加2个 = 6个破折号 ❌
```

## 解决方案
```python
boundary = 'WebKitFormBoundary' + random_hex      # 不含破折号
body_parts.append(f'--{boundary}\r\n')            # 添加2个 = 2个破折号 ✅
```

**修复前：** `------WebKitFormBoundary...`  
**修复后：** `--WebKitFormBoundary...`

## Test plan
- [ ] 手动触发部署 llm-client 1.0.1
- [ ] 验证 FastAPI 能正确解析 multipart 数据
- [ ] 确认部署任务成功触发

🤖 Generated with [Claude Code](https://claude.ai/code)