### PR TITLE
feat: 添加高德地图天气查询预制件

### DIFF
--- a/prefabs/releases/community-prefabs.json
+++ b/prefabs/releases/community-prefabs.json
@@ -7,5 +7,14 @@
     "name": "大模型客户端预制件",
     "description": "智能内容分析与生成工具，支持文本理解、摘要生成、内容分类、情感分析等 AI 能力。基于 OpenAI 兼容 API，支持流式和非流式返回",
     "tags": ["llm", "ai", "大模型", "内容分析", "文本生成"]
+  },
+  {
+    "id": "amap-weather-prefab",
+    "version": "1.0.0",
+    "author": "ketd",
+    "repo_url": "https://github.com/ketd/Amap-Weather",
+    "name": "高德地图天气查询预制件",
+    "description": "基于高德地图 API 的天气查询预制件，支持实时天气和天气预报查询",
+    "tags": ["weather", "amap", "天气"]
   }
 ]


### PR DESCRIPTION
## Summary
添加 amap-weather-prefab 到社区预制件列表

## 详细信息
- **预制件名称**: 高德地图天气查询预制件
- **预制件ID**: amap-weather-prefab
- **版本**: 1.0.0
- **作者**: ketd
- **功能**: 基于高德地图 API 的天气查询预制件，支持实时天气和天气预报查询

## Test plan
- [ ] 验证 JSON 格式正确
- [ ] 确认预制件信息完整
- [ ] 检查仓库链接有效性