### PR TITLE
Fix log level typo in settings.toml

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -12,7 +12,7 @@ backup_count = 5
 debug_enabled = true
 log_requests = true
 log_responses = true
-log_level = "DEBUGE"
+log_level = "DEBUG"
 log_to_file = true
 log_to_console = false  # 关闭控制台输出
 


### PR DESCRIPTION
This pull request makes a minor correction to the logging configuration in `settings.toml`, fixing a typo in the log level setting. The log level is now correctly set to `"DEBUG"` instead of the invalid `"DEBUGE"`.