### PR TITLE
feat: add manual build index workflow

### DIFF
--- a/.github/workflows/manual-build-index.yml
+++ b/.github/workflows/manual-build-index.yml
@@ -1,0 +1,59 @@
+name: Manual Build Prefab Index
+
+# 手动触发构建预制件索引
+on:
+  workflow_dispatch:
+    inputs:
+      force_rebuild:
+        description: 'Force rebuild index (default: true)'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  build-index:
+    name: Build Prefab Index
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          pip install -q requests
+
+      - name: Build prefab index
+        env:
+          VECTOR_SERVICE_URL: ${{ secrets.VECTOR_SERVICE_URL }}
+        run: |
+          echo "🔨 Starting manual prefab index build..."
+          echo "   Force rebuild: ${{ inputs.force_rebuild }}"
+          echo "   Vector service: $VECTOR_SERVICE_URL"
+          echo ""
+
+          python3 prefabs/releases/scripts/build_index.py \
+            --vector-service-url "$VECTOR_SERVICE_URL" \
+            --input prefabs/releases/community-prefabs.json
+
+      - name: Index build summary
+        if: success()
+        run: |
+          echo "✅ Prefab index built successfully"
+          echo "   The vector service now has the latest prefab data"
+          echo "   You can now use prefab search and call_prefab_function tools"
+
+      - name: Index build failed
+        if: failure()
+        run: |
+          echo "❌ Failed to build prefab index"
+          echo "   Please check:"
+          echo "   1. VECTOR_SERVICE_URL secret is correctly configured"
+          echo "   2. Vector service is accessible from GitHub Actions"
+          echo "   3. community-prefabs.json format is valid"
+          echo "   4. Check the logs above for detailed error messages"


### PR DESCRIPTION
## 概述

添加独立的手动构建预制件索引 workflow，方便运维人员在需要时手动重建索引。

## 为什么需要这个 Workflow？

当前的索引构建机制：
- ✅ **自动构建**：当 `community-prefabs.json` 更新时，通过 "Prefab Deploy on Merge" workflow 自动构建
- ❌ **手动构建**：缺少独立的手动触发方式

但在以下场景中，需要手动重建索引：
1. 向量服务重启后需要重建索引
2. 索引数据损坏需要修复
3. 测试索引构建功能
4. 配置更新后需要重新索引

## 主要变更

### 新增文件

**`.github/workflows/manual-build-index.yml`**

专门用于手动构建索引的 workflow：

```yaml
name: Manual Build Prefab Index

on:
  workflow_dispatch:
    inputs:
      force_rebuild:
        description: 'Force rebuild index (default: true)'
        required: false
        default: true
        type: boolean
```

### 功能特性

- **纯手动触发**：只能通过 GitHub Actions UI 手动运行，不会自动触发
- **简单参数**：只有一个可选的 `force_rebuild` 参数（默认为 true）
- **清晰的输出**：提供详细的构建进度和错误提示
- **独立功能**：专注于索引构建，不涉及预制件部署

### 使用方式

1. 打开 GitHub Actions 页面
2. 选择 "Manual Build Prefab Index" workflow
3. 点击 "Run workflow" 按钮
4. （可选）调整 `force_rebuild` 参数
5. 点击绿色的 "Run workflow" 确认

### 输出示例

**成功时：**
```
✅ Prefab index built successfully
   The vector service now has the latest prefab data
   You can now use prefab search and call_prefab_function tools
```

**失败时：**
```
❌ Failed to build prefab index
   Please check:
   1. VECTOR_SERVICE_URL secret is correctly configured
   2. Vector service is accessible from GitHub Actions
   3. community-prefabs.json format is valid
   4. Check the logs above for detailed error messages
```

## 与现有 Workflow 的关系

| Workflow | 触发方式 | 用途 |
|----------|---------|------|
| **Prefab Deploy on Merge** | 自动（push to main + 修改 JSON） | 自动构建索引 + 部署预制件 |
| **Manual Build Prefab Index** ✨ | 手动（workflow_dispatch） | 按需重建索引 |

## 配置要求

需要在 GitHub Secrets 中配置：
- `VECTOR_SERVICE_URL`: 向量服务地址

## 测试

- ✅ YAML 语法验证通过
- ✅ 与现有 workflow 无冲突
- ⏳ 待合并后在 GitHub Actions UI 中测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)